### PR TITLE
Allow Odoo Configuration from the Locust Web UI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,25 +28,31 @@ Usage
 -----
 
 For the general documentation on Locust, heads on https://docs.locust.io/en/latest/
-A few options can be customized with environment variables:
+A few options can be customized with environment variables or command line parameters. These
+can also be specified in the Locust Web UI now.
 
-+--------------+-------------------------------------------------------------+
-|Name          |Usage                                                        |
-+--------------+-------------------------------------------------------------+
-|ODOO_DB_NAME  |Configure the name of the database to load-test              |
-|              |(default: odoo)                                              |
-+--------------+-------------------------------------------------------------+
-|ODOO_LOGIN    |Login to use for the actions (default: admin)                |
-+--------------+-------------------------------------------------------------+
-|ODOO_PASSWORD |Password for the user (default: admin)                       |
-+--------------+-------------------------------------------------------------+
-|ODOO_VERSION  |Force an Odoo version (e.g. 9.0, 10.0, 11.0), normally       |
-|              |automatically recognized                                     |
-+--------------+-------------------------------------------------------------+
++--------------+------------------+-------------------------------------------------------------+
+|Name          |Option            |Usage                                                        |
++--------------+------------------+-------------------------------------------------------------+
+|ODOO_DB_NAME  |--odoo-db-name    |Configure the name of the database to load-test              |
+|              |                  |(default: odoo)                                              |
++--------------+------------------+-------------------------------------------------------------+
+|ODOO_LOGIN    |--odoo-login      |Login to use for the actions (default: admin)                |
++--------------+------------------+-------------------------------------------------------------+
+|ODOO_PASSWORD |--odoo-password   |Password for the user (default: admin)                       |
++--------------+------------------+-------------------------------------------------------------+
+|ODOO_VERSION  |--odoo-version    |Force an Odoo version (e.g. 9.0, 10.0, 11.0), normally       |
+|              |                  |automatically recognized                                     |
++--------------+------------------+-------------------------------------------------------------+
 
 Example::
 
   ODOO_DB_NAME=demo locust -f examples/locustfile.py --host http://localhost:8069 
+
+
+Also Valid::
+
+  locust -f examples/locustfile.py --host http://localhost:8069 --odoo-db-name=demo
 
 
 Check the `examples <https://github.com/camptocamp/locustodoorpc/tree/master/examples>`_

--- a/locustodoorpc/client.py
+++ b/locustodoorpc/client.py
@@ -22,6 +22,13 @@ else:
     from urllib2 import HTTPError, URLError
 
 
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument("--odoo-db-name", type=str, env_var="ODOO_DB_NAME", default="odoo", help="Target Odoo Database")
+    parser.add_argument("--odoo-login", type=str, env_var="ODOO_LOGIN", default="admin", help="Target Odoo User")
+    parser.add_argument("--odoo-password", type=str, env_var="ODOO_PASSWORD", default="", help="Target Odoo User Password")
+    parser.add_argument("--odoo-version", type=str, env_var="ODOO_VERSION", default="", help="Target Odoo Version")
+
 class ODOOLocustClient(odoorpc.ODOO):
 
     def capture_request(request_type):
@@ -86,19 +93,17 @@ class OdooRPCLocust(HttpUser):
 
     """
 
-    db_name = os.getenv('ODOO_DB_NAME', 'odoo')
-    login = os.getenv('ODOO_LOGIN', 'admin')
-    password = os.getenv('ODOO_PASSWORD', 'admin')
     wait_time = between(1, 2)
     tasks = []
     abstract = True
 
-    # allow to force Odoo version (avoid auto-detection)
-    version = os.getenv('ODOO_VERSION')
-
     def __init__(self, *args, **kwargs):
         super(OdooRPCLocust, self).__init__(*args, **kwargs)
         url = urlparse(self.host)
+        self.db_name = self.environment.parsed_options.odoo_db_name
+        self.login = self.environment.parsed_options.odoo_login
+        self.password = self.environment.parsed_options.odoo_password
+        self.version = self.environment.parsed_options.odoo_version
         port = url.port
         if url.scheme == 'https':
             if not port:

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     license='LGPLv3+',
     packages=['locustodoorpc'],
     install_requires=[
-      'odoorpc >= 0.8.0',
-      'locust >= 1.1.1',
+      'odoorpc >= 0.9.0',
+      'locust >= 2.13.0',
     ],
     classifiers=(
         'Development Status :: 3 - Alpha',
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ),
 )


### PR DESCRIPTION
I'm not sure of the current rules/guidelines for contribution in the repository, but these changes allow the Odoo configuration details (host, db, user, password, and version) to be set at the command line or in the Web UI. This change makes it really easy to run a test against one Odoo instance, then immediately test a different one without restarting Locust, but will only work for newer versions of Locust.